### PR TITLE
Change name of MainActivity extension from .k to .kt

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-explore-composables.md
+++ b/topics/compose-onboard/compose-multiplatform-explore-composables.md
@@ -102,7 +102,7 @@ controller, and on desktop by a window. Let's examine each of them.
 
 ### On Android
 
-For Android, open the `MainActivity.k ` file in `composeApp/src/androidMain/kotlin`:
+For Android, open the `MainActivity.kt ` file in `composeApp/src/androidMain/kotlin`:
 
 ```kotlin
 class MainActivity : ComponentActivity() {


### PR DESCRIPTION
When I was going throught the documentation I realized that a ´t´ is missing from MainActivity.k. This is a minor issues but I thought it might help other beginners in the future.