### PR TITLE
fix: change the syntax of the lifecycle-viewmodel-compose dependency

### DIFF
--- a/topics/multiplatfrom-onboard/multiplatform-upgrade-app.md
+++ b/topics/multiplatfrom-onboard/multiplatform-upgrade-app.md
@@ -300,7 +300,7 @@ The view model will manage the data from the activity and won't disappear when t
         // ...
         implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
         implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
-        implementation(libs.androidx.lifecycle.viewmodel.compose)
+        implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
     }
     ```
 


### PR DESCRIPTION
Different styles of dependencies don't work well with copy-paste. This is a quick fix for the tutorial experience. In the future, we'll probably update this step to use the version catalog explicitly.