### PR TITLE
Update multiplatform-integrate-in-existing-app.md

### DIFF
--- a/topics/multiplatform-integrate-in-existing-app.md
+++ b/topics/multiplatform-integrate-in-existing-app.md
@@ -333,7 +333,11 @@ Connect your framework to the iOS project manually:
 
    ![User Script Sandboxing](disable-sandboxing-in-xcode-project-settings.png){width=700}
 
-7. Build the project in Xcode. If everything is set up correctly, the project will successfully build.
+   > This may require restarting your Gradle daemon
+   >
+   {type="note"}
+   
+8. Build the project in Xcode. If everything is set up correctly, the project will successfully build.
 
 > If you have a custom build configuration different from the default `Debug` or `Release`, on the **Build Settings**
 > tab, add the `KOTLIN_FRAMEWORK_BUILD_TYPE` setting under **User-Defined** and set it to `Debug` or `Release`.

--- a/topics/multiplatform-integrate-in-existing-app.md
+++ b/topics/multiplatform-integrate-in-existing-app.md
@@ -333,9 +333,13 @@ Connect your framework to the iOS project manually:
 
    ![User Script Sandboxing](disable-sandboxing-in-xcode-project-settings.png){width=700}
 
-   > This may require restarting your Gradle daemon
+   > This may require restarting your Gradle daemon, if you built the project without disabling sandboxing first.
+   > Stop the Gradle daemon process that might have been sandboxed:
+   > ```shell
+   > ./gradlew --stop
+   > ```
    >
-   {type="note"}
+   > {type="tip"}
    
 7. Build the project in Xcode. If everything is set up correctly, the project will successfully build.
 

--- a/topics/multiplatform-integrate-in-existing-app.md
+++ b/topics/multiplatform-integrate-in-existing-app.md
@@ -337,7 +337,7 @@ Connect your framework to the iOS project manually:
    >
    {type="note"}
    
-8. Build the project in Xcode. If everything is set up correctly, the project will successfully build.
+7. Build the project in Xcode. If everything is set up correctly, the project will successfully build.
 
 > If you have a custom build configuration different from the default `Debug` or `Release`, on the **Build Settings**
 > tab, add the `KOTLIN_FRAMEWORK_BUILD_TYPE` setting under **User-Defined** and set it to `Debug` or `Release`.


### PR DESCRIPTION
Hi 👋  After disabling sandboxing, the Gradle daemon needs to be restarted. If reading the manual line by line, it shouldn't be an issue but when using it as a reference, it's easy to get a daemon in the "bad" state.