### PR TITLE
update: rename get started in tutorials

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-getting-started.md
+++ b/topics/compose-onboard/compose-multiplatform-getting-started.md
@@ -1,4 +1,4 @@
-[//]: # (title: Get started with Compose Multiplatform — tutorial)
+[//]: # (title: Create a Compose Multiplatform app — tutorial)
 
 With the [Compose Multiplatform](https://www.jetbrains.com/lp/compose-multiplatform/) UI framework, you can push the
 code-sharing capabilities of Kotlin Multiplatform beyond application logic. You can implement the user interface once

--- a/topics/multiplatfrom-onboard/multiplatform-getting-started.md
+++ b/topics/multiplatfrom-onboard/multiplatform-getting-started.md
@@ -1,4 +1,4 @@
-[//]: # (title: Get started with Kotlin Multiplatform — tutorial)
+[//]: # (title: Create a Kotlin Multiplatform app — tutorial)
 [//]: # (description: Simplify cross-platform app development with Kotlin Multiplatform. Create a single codebase
 for the business logic of your iOS and Android apps.)
 


### PR DESCRIPTION
a temporary workaround for the duplicated Get Started issue: it's bad timing for a revolution with removing pages and changing links, but we can try renaming instead