### PR TITLE
Add Rijksmuseum to multiplatform-samples

### DIFF
--- a/topics/multiplatform-samples.md
+++ b/topics/multiplatform-samples.md
@@ -523,4 +523,36 @@ to add your Kotlin Multiplatform project to these topics and help the community.
           </list>
       </td>
   </tr>
+  
+  <tr>
+        <td>
+            <strong><a href="https://github.com/fethij/Rijksmuseum">Rijksmuseum</a></strong>
+        </td>
+        <td>Rijksmuseum is a multimodular Kotlin and Compose Multiplatform app that offers an immersive way to explore the art collection of the renowned Rijksmuseum in Amsterdam. It utilizes the Rijksmuseum API to fetch and display detailed information about various artworks, including images and descriptions.</td>
+        <td>
+          <list>
+            <li>UI</li>
+            <li>Model</li>
+            <li>Networking</li>
+            <li>Navigation</li>
+            <li>ViewModel</li>
+          </list>
+        </td>
+        <td>
+          <list>
+            <li><code>kotlinx-coroutines</code></li>
+            <li><code>kotlinx-serialization</code></li>
+            <li><code>ktor-client</code></li>
+            <li><code>koin</code></li>
+            <li><code>Compose Navigation</code></li>
+            <li><code>Coil</code></li>
+            <li><code>Jetpack ViewModel</code></li>
+          </list>
+        </td>
+        <td>
+            <list>
+                <li>Compose Multiplatform on Android, iOS, desktop, and web</li>
+            </list>
+        </td>
+    </tr>
 </table>


### PR DESCRIPTION
Hallo, Rijksmuseum is Kotlin and Compose Multiplatform app that offers an immersive way to explore the art collection of the renowned Rijksmuseum in Amsterdam. The project is multi-modular and uses compose for all platforms (Android, iOS, desktop and web). It also showcases topics like DI, Networking, Navigation, Caching and Sharing build logic between subprojects/modules...

If this is a good sample for people, please include it in the doc, or else feel free to close the PR.

Here is the repo: https://github.com/fethij/rijksmuseum