### PR TITLE
Fix grammar referencing Google's announcement

### DIFF
--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -272,5 +272,5 @@ composeCompiler {
 
 ## What's next
 
-* See the [Google's announcement](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) about Compose compiler moving to the Kotlin repository.
+* See [Google's announcement](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) about Compose compiler moving to the Kotlin repository.
 * If you are using Jetpack Compose to build an Android app, check out [our guide on how to make it multiplatform](multiplatform-integrate-in-existing-app.md).

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -272,5 +272,5 @@ composeCompiler {
 
 ## What's next
 
-* See [Google's announcement](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) about Compose compiler moving to the Kotlin repository.
+* See [Google's announcement](https://android-developers.googleblog.com/2024/04/jetpack-compose-compiler-moving-to-kotlin-repository.html) about the Compose compiler moving to the Kotlin repository.
 * If you are using Jetpack Compose to build an Android app, check out [our guide on how to make it multiplatform](multiplatform-integrate-in-existing-app.md).


### PR DESCRIPTION
Calling it "the Google" is funny, but that probably won't be standard until at least 2026