### PR TITLE
fix: clarifying the migration steps

### DIFF
--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -72,7 +72,8 @@ To resolve this, delete all of the `build` directories: at the root of your proj
 ## Migrating a Jetpack Compose project
 
 When migrating to Kotlin 2.0.0 or newer from 1.9, you should adjust your project configuration depending on the way you deal with
-the Compose compiler now. We recommend using the Kotlin Gradle plugin and the Compose compiler Gradle plugin for best results. 
+the Compose compiler now. We recommend using the Kotlin Gradle plugin and the Compose compiler Gradle plugin
+to automate configuration management. 
 
 ### Managing the Compose compiler with Gradle plugins
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -107,8 +107,8 @@ For Android modules that do not rely on Compose Multiplatform:
 4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compiler options](#compose-compiler-options-dsl) for reference.
 
-> If you are not using Gradle plugins to manage the Compose compiler, you should update the direct references to old Maven
-> artifacts:
+> If you are not using Gradle plugins to manage the Compose compiler, update any direct references to old Maven
+> artifacts in your project:
 > 
 >   * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`
 >   * Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin`

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -71,6 +71,9 @@ To resolve this, delete all of the `build` directories: at the root of your proj
 
 ## Migrating a Jetpack Compose project
 
+When migrating to Kotlin 2.0.0 or newer from 1.9, you should adjust your project configuration depending on the way you deal with
+the Compose compiler now.
+
 ### Managing the Compose compiler with Gradle plugins
 
 For Android modules that do not rely on Compose Multiplatform: 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -72,7 +72,7 @@ To resolve this, delete all of the `build` directories: at the root of your proj
 ## Migrating a Jetpack Compose project
 
 When migrating to Kotlin 2.0.0 or newer from 1.9, you should adjust your project configuration depending on the way you deal with
-the Compose compiler now.
+the Compose compiler now. We recommend using the Kotlin Gradle plugin and the Compose compiler Gradle plugin for best results. 
 
 ### Managing the Compose compiler with Gradle plugins
 
@@ -111,6 +111,9 @@ For Android modules that do not rely on Compose Multiplatform:
 
 4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compiler options](#compose-compiler-options-dsl) for reference.
+
+5. If you reference Compose compiler artifacts directly, you can remove these references and let the Gradle plugins
+   take care of things.
 
 ### Using Compose compiler without Gradle plugins
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -71,6 +71,8 @@ To resolve this, delete all of the `build` directories: at the root of your proj
 
 ## Migrating a Jetpack Compose project
 
+### Managing the Compose compiler with Gradle plugins
+
 For Android modules that do not rely on Compose Multiplatform: 
 
 1. Add the Compose compiler Gradle plugin to the [Gradle version catalog](https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml):
@@ -107,13 +109,13 @@ For Android modules that do not rely on Compose Multiplatform:
 4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compiler options](#compose-compiler-options-dsl) for reference.
 
-> If you are not using Gradle plugins to manage the Compose compiler, update any direct references to old Maven
-> artifacts in your project:
-> 
->   * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`
->   * Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin`
->
-{type="note"}
+### Using Compose compiler without Gradle plugins
+
+If you are not using Gradle plugins to manage the Compose compiler, update any direct references to old Maven
+artifacts in your project:
+
+  * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`
+  * Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin`
 
 ## Compose compiler options DSL
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -59,11 +59,6 @@ module that uses the `org.jetbrains.compose` plugin:
 4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compose Compiler options DSL](#compose-compiler-options-dsl) for reference.
 
-   > The Gradle plugin provides defaults for several compiler options that were only specified manually before.
-   > If you have any of them set up with `freeCompilerArgs`, for example, Gradle will report a duplicate options error.
-   >
-   {type="warning"}
-
 #### Possible issue: "Missing resource with path"
 
 When switching from Kotlin 1.9.0 to 2.0.0, or from 2.0.0 to 1.9.0, you may encounter the following error:
@@ -109,18 +104,16 @@ For Android modules that do not rely on Compose Multiplatform:
     }
     ```
 
-4. If you reference the old Maven artifacts directly, you'll need to update these references:
-
-   * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:compose-compiler-gradle-plugin-embeddable`
-   * Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:compose-compiler-gradle-plugin`
-
-5. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
+4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compiler options](#compose-compiler-options-dsl) for reference.
 
-   > The Gradle plugin provides defaults for several compiler options that were only specified manually before.
-   > If you have any of them set up with `freeCompilerArgs`, for example, Gradle will report a duplicate options error.
-   >
-   {type="warning"}
+> If you are not using Gradle and thus unable to enjoy Gradle plugins, you should update the direct references to old Maven
+> artifacts:
+> 
+>   * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`
+>   * Change `androidx.compose.compiler:compiler-hosted` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin`
+>
+{type="note"}
 
 ## Compose compiler options DSL
 
@@ -133,6 +126,11 @@ composeCompiler {
    enableStrongSkippingMode = true
 }
 ```
+
+> The Gradle plugin provides defaults for several Compose compiler options that were only specified manually before.
+> If you have any of them set up with `freeCompilerArgs`, for example, Gradle will report a duplicate options error.
+>
+{type="warning"}
 
 ### generateFunctionKeyMetaClasses
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -107,7 +107,7 @@ For Android modules that do not rely on Compose Multiplatform:
 4. If you are using compiler options for the Jetpack Compose compiler, set them in the `composeCompiler {}` block.
    See [Compiler options](#compose-compiler-options-dsl) for reference.
 
-> If you are not using Gradle and thus unable to enjoy Gradle plugins, you should update the direct references to old Maven
+> If you are not using Gradle plugins to manage the Compose compiler, you should update the direct references to old Maven
 > artifacts:
 > 
 >   * Change `androidx.compose.compiler:compiler` to `org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable`


### PR DESCRIPTION
Here we're trying to make sure that users don't take unnecessary steps during migration: referencing Compose compiler Maven artifacts directly is only necessary if there is no Gradle plugin to resolve them.