### PR TITLE
Fix Sample Code: Add async notation at func startObserving in ContentView

### DIFF
--- a/topics/multiplatfrom-onboard/multiplatform-upgrade-app.md
+++ b/topics/multiplatfrom-onboard/multiplatform-upgrade-app.md
@@ -530,7 +530,7 @@ Return to Xcode and update the code using the library:
         class ViewModel: ObservableObject {
             @Published var greetings: [String] = []
             
-            func startObserving() {
+            func startObserving() async {
                 for await phrase in Greeting().greet() {
                     self.greetings.append(phrase)
                 }


### PR DESCRIPTION
# About
I updated sample code in `topics/multiplatfrom-onboard/multiplatform-upgrade-app.md`.
In line 534, `await` is used in func `startObserving` but its function is not defined as async function. 
This misnotation caused build error in my environment, detailed environment is below.

# Changes

Here are the document of lines 526 through 540 in `topics/multiplatfrom-onboard/multiplatform-upgrade-app.md`

```Swift
 // ...
 extension ContentView {
     @MainActor
     class ViewModel: ObservableObject {
         @Published var greetings: [String] = []
         
-         func startObserving() {
+         func startObserving() async {
             for await phrase in Greeting().greet() {
                 self.greetings.append(phrase)
             }
         }
     }
 }
```

# Environment

- macOS Sonoma 14.5 (M1)
- Android Studio Koala 2024.1.1
- Xcode 15.4

# Stackoverflow

- ['async' call in a function that does not support concurrency](https://stackoverflow.com/questions/67925525/async-call-in-a-function-that-does-not-support-concurrency)