### PR TITLE
Revert "update: warning about instability of older dependencies"

### DIFF
--- a/topics/compose/compose-compatibility-and-versioning.md
+++ b/topics/compose/compose-compatibility-and-versioning.md
@@ -37,15 +37,6 @@ Remember that using an EAP version of either product is still potentially unstab
 Compose Multiplatform requires Compose Compiler Gradle plugin applied with the same version as the Kotlin one.
 See [](compose-compiler.md#migrating-a-compose-multiplatform-project) for details.
 
-> It is strongly recommended to update your Compose app made for Kotlin 2.0.0 to the 2.0.10 version or newer to avoid
-> unnecessary (or endless) recomposition issues on non-JVM targets.
->
-> If your app is built with Compose compiler 2.0.10 or newer but uses dependencies built with Compose compiler 2.0.0,
-> these older dependencies may still cause recomposition issues.
-> To prevent this, update your dependencies to versions built with the same Compose compiler as your app.
->
-{type="warning"}
-
 ## Jetpack Compose and Compose Multiplatform release cycles
 
 Compose Multiplatform shares a lot of code with [Jetpack Compose](https://developer.android.com/jetpack/compose) for

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -5,21 +5,13 @@ easier access to compiler options.
 When applied with the Android Gradle plugin (AGP), this Compose compiler plugin will override the coordinates
 of the Compose compiler supplied automatically by AGP.
 
-The Compose compiler has been merged into the Kotlin repository since Kotlin 2.0.0.
-This helps smooth the migration of your projects to Kotlin 2.0.0 and newer, as the Compose compiler ships
-simultaneously with Kotlin and will always be compatible with Kotlin of the same version.
-
-> It is strongly recommended to update your Compose app made for Kotlin 2.0.0 to the 2.0.10 version or newer to avoid
-> unnecessary (or endless) recomposition issues on non-JVM targets.
-> 
-> If your app is built with Compose compiler 2.0.10 or newer but uses dependencies built with Compose compiler 2.0.0,
-> these older dependencies may still cause recomposition issues.
-> To prevent this, update your dependencies to versions built with the same Compose compiler as your app.
+> The Compose compiler has been merged into the Kotlin repository since Kotlin %kotlinVersion%.
+> This helps smooth the migration of your projects to Kotlin %kotlinVersion%, as the Compose compiler ships
+> simultaneously with Kotlin and will always be compatible with Kotlin of the same version.
 >
-{type="warning"}
+{type="tip"}
 
-To use the new Compose compiler plugin in your project, apply it for each module that uses Compose.
-See the migration instructions below:
+To use it in your project, apply the plugin for each module that uses Compose. See the migration instructions below:
 
 * [Migrating a Compose Multiplatform project](#migrating-a-compose-multiplatform-project)
 * [Migrating a Jetpack Compose project](#migrating-a-jetpack-compose-project)


### PR DESCRIPTION
I got a little ahead of myself, isn't supposed to be merged before 2.0.10