### PR TITLE
update: circuit framework added

### DIFF
--- a/topics/compose/compose-navigation-routing.md
+++ b/topics/compose/compose-navigation-routing.md
@@ -68,4 +68,4 @@ there are third-party alternatives that you can choose from:
 | [Decompose](https://arkivanov.github.io/Decompose/) | An advanced approach to navigation that covers the full lifecycle and any potential dependency injection                                                        |
 | [Appyx](https://bumble-tech.github.io/appyx/)       | Model-driven navigation with gesture control                                                                                                                    |
 | [PreCompose](https://tlaster.github.io/PreCompose/) | A navigation and view model inspired by Jetpack Lifecycle, ViewModel, LiveData, and Navigation                                                                  |
-| [Circuit](hhttps://slackhq.github.io/circuit/)      | A lightweight and extensible Compose framework for building Kotlin applications. It uses a custom Compose-based backstack implementation for navigable contents |
+| [Circuit](https://slackhq.github.io/circuit/)      | A lightweight and extensible Compose framework for building Kotlin applications, with a Compose-based backstack for navigation |

--- a/topics/compose/compose-navigation-routing.md
+++ b/topics/compose/compose-navigation-routing.md
@@ -62,9 +62,10 @@ Current limitations of navigation in Compose Multiplatform, compared to Jetpack 
 If the Compose Multiplatform navigation components do not solve your problems,
 there are third-party alternatives that you can choose from:
 
-| Name                                                | Description                                                                                              |
-|-----------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-| [Voyager](https://voyager.adriel.cafe)              | A pragmatic approach to navigation                                                                       |
-| [Decompose](https://arkivanov.github.io/Decompose/) | An advanced approach to navigation that covers the full lifecycle and any potential dependency injection |
-| [Appyx](https://bumble-tech.github.io/appyx/)       | Model-driven navigation with gesture control                                                             |
-| [PreCompose](https://tlaster.github.io/PreCompose/) | A navigation and view model inspired by Jetpack Lifecycle, ViewModel, LiveData, and Navigation           |
+| Name                                                | Description                                                                                                                                                     |
+|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [Voyager](https://voyager.adriel.cafe)              | A pragmatic approach to navigation                                                                                                                              |
+| [Decompose](https://arkivanov.github.io/Decompose/) | An advanced approach to navigation that covers the full lifecycle and any potential dependency injection                                                        |
+| [Appyx](https://bumble-tech.github.io/appyx/)       | Model-driven navigation with gesture control                                                                                                                    |
+| [PreCompose](https://tlaster.github.io/PreCompose/) | A navigation and view model inspired by Jetpack Lifecycle, ViewModel, LiveData, and Navigation                                                                  |
+| [Circuit](hhttps://slackhq.github.io/circuit/)      | A lightweight and extensible Compose framework for building Kotlin applications. It uses a custom Compose-based backstack implementation for navigable contents |


### PR DESCRIPTION
[KT-70402](https://youtrack.jetbrains.com/issue/KT-70402). This PR adds the Circuit framework to the list of third-party navigation libraries