### PR TITLE
fix: instruction broken with the latest wizard

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-create-first-app.md
+++ b/topics/compose-onboard/compose-multiplatform-create-first-app.md
@@ -230,7 +230,7 @@ You can create a run configuration for running the desktop application as follow
 2. Click the plus button and choose **Gradle** from the dropdown list.
 3. In the **Tasks and arguments** field, paste this command:
    ```shell
-   desktopRun -DmainClass=MainKt --quiet
+   composeApp:run
    ```
 4. Click **OK**.
 


### PR DESCRIPTION
There is no class now, but we could also make the run configuration class agnostic. 