### PR TITLE
Update 2.0.0 Compose compiler warning

### DIFF
--- a/topics/compose/compose-compatibility-and-versioning.md
+++ b/topics/compose/compose-compatibility-and-versioning.md
@@ -37,8 +37,9 @@ Remember that using an EAP version of either product is still potentially unstab
 Compose Multiplatform requires Compose Compiler Gradle plugin applied with the same version as the Kotlin one.
 See [](compose-compiler.md#migrating-a-compose-multiplatform-project) for details.
 
-> It's strongly recommended that you update your Compose app created with Kotlin 2.0.0 to version 2.0.10 or later to avoid
-> unnecessary (or endless) recomposition issues on non-JVM targets.
+> It's strongly recommended that you update your Compose app created with Kotlin 2.0.0 to version 2.0.10 or later. The Compose
+> compiler 2.0.0 has an issue where it sometimes incorrectly infers the stability of types in multiplatform projects with
+> non-JVM targets, which can lead to unnecessary (or even endless) recompositions.
 >
 > If your app is built with Compose compiler 2.0.10 or later but uses dependencies built with Compose compiler 2.0.0,
 > these older dependencies may still cause recomposition issues.

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -9,9 +9,10 @@ The Compose compiler has been merged into the Kotlin repository since Kotlin 2.0
 This helps smooth the migration of your projects to Kotlin 2.0.0 and later, as the Compose compiler ships
 simultaneously with Kotlin and will always be compatible with Kotlin of the same version.
 
-> It's strongly recommended that you update your Compose app created with Kotlin 2.0.0 to version 2.0.10 or later to avoid
-> unnecessary (or endless) recomposition issues on non-JVM targets.
-> 
+> It's strongly recommended that you update your Compose app created with Kotlin 2.0.0 to version 2.0.10 or later. The Compose
+> compiler 2.0.0 has an issue where it sometimes incorrectly infers the stability of types in multiplatform projects with
+> non-JVM targets, which can lead to unnecessary (or even endless) recompositions.
+>
 > If your app is built with Compose compiler 2.0.10 or later but uses dependencies built with Compose compiler 2.0.0,
 > these older dependencies may still cause recomposition issues.
 > To prevent this, update your dependencies to versions built with the same Compose compiler as your app.


### PR DESCRIPTION
As a result of https://github.com/JetBrains/kotlin-web-site/pull/4349 we should align the warning text for the Compose compiler 2.0.0 version.