### PR TITLE
update: 2.0.20 update to the composeCompiler {} block

### DIFF
--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -9,7 +9,7 @@ The Compose compiler has been merged into the Kotlin repository since Kotlin 2.0
 This helps smooth the migration of your projects to Kotlin 2.0.0 and later, as the Compose compiler ships
 simultaneously with Kotlin and will always be compatible with Kotlin of the same version.
 
-> It is strongly recommended that you update your Compose app created with Kotlin 2.0.0 to version 2.0.10 or later. The Compose
+> It is strongly recommended that you update your multiplatform Compose app created with Kotlin 2.0.0 to version 2.0.10 or later. The Compose
 > compiler 2.0.0 has an issue where it sometimes incorrectly infers the stability of types in multiplatform projects with
 > non-JVM targets, which can lead to unnecessary (or even endless) recompositions.
 >
@@ -304,7 +304,7 @@ and functions that are implicitly not skippable (inline functions and functions 
 
 If enabled, turns on Strong Skipping mode.
 
-Strong Skipping mode improves the runtime performance of your application by skipping unnecessary invocations
+Strong Skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values.
 of composable functions whose parameters haven't changed.
 For example, composables with unstable parameters become skippable, and lambdas with unstable captures are memoized.
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -141,10 +141,10 @@ you're applying the plugin to.
 
 There are two kinds of options you can specify:
 
-   * Settings for various metadata, for example, reports folders or source information.
-   * Feature flags that turn certain compiler features on or off.
-     Feature flags are separated into their own set to avoid churn of top-level properties
-     and help roll out (or deprecate) features and defaults.
+   * General compiler settings.
+   * Feature flags enabling or disabling new and experimental features which eventually should become baseline.
+     Feature flags are separated into their own set to avoid churn of top-level properties as new flags
+     are rolled out and deprecated continuously.
 
 An example of such a configuration:
 
@@ -164,7 +164,7 @@ composeCompiler {
 >
 {type="warning"}
 
-### Metadata settings
+### General settings
 
 #### generateFunctionKeyMetaClasses
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -301,9 +301,9 @@ and functions that are implicitly not skippable (inline functions and functions 
 
 **Default**: enabled
 
-If enabled, turns on Strong Skipping mode.
+If enabled, turns on strong skipping mode.
 
-Strong Skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values of composable functions whose parameters haven't changed.
+Strong skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values of composable functions whose parameters haven't changed.
 For example, composables with unstable parameters become skippable, and lambdas with unstable captures are memoized.
 
 For details, see the [description of Strong Skipping mode](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -279,7 +279,7 @@ featureFlags = setOf(ComposeFeatureFlag.StrongSkipping.disabled())
 
 If enabled, turns on intrinsic remember performance optimization.
 
-Intrinsic remember is an optimization mode that inlines `remember` invocations and, where possible, replaces `.equals` comparisons for keys with comparisons of the `$changed` meta parameter.
+Intrinsic remember is an optimization mode that inlines `remember` invocations and, where possible, replaces `.equals()` comparisons for keys with comparisons of the `$changed` meta parameter.
 This results in fewer slots being used and fewer comparisons being made at runtime.
 
 #### OptimizeNonSkippingGroups

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -143,8 +143,6 @@ There are two kinds of options you can specify:
 
    * General compiler settings.
    * Feature flags enabling or disabling new and experimental features which eventually should become baseline.
-     Feature flags are separated into their own set to avoid churn of top-level properties as new flags
-     are rolled out and deprecated continuously.
 
 An example of such a configuration:
 
@@ -259,6 +257,9 @@ composeCompiler {
 ```
 
 ### Feature flags
+
+Feature flags are separated into their own set to avoid churn of top-level properties as new flags
+are rolled out and deprecated continuously.
 
 To enable a feature flag that is disabled by default, specify it in the set, for example:
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -176,7 +176,7 @@ If `true`, generate function key meta classes with annotations indicating the fu
 
 **Type**: `Property<Boolean>`
 
-**Default**: `false`
+**Default**: `false` (`true` for Android)
 
 If `true`, include source information in generated code.
 
@@ -220,7 +220,7 @@ in the Jetpack Compose documentation.
 
 **Type**: `Property<Boolean>`
 
-**Default**: `false`
+**Default**: `true`
 
 If `true`, include composition trace markers in the generated code.
 

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -306,7 +306,7 @@ If enabled, turns on strong skipping mode.
 Strong skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values of composable functions whose parameters haven't changed.
 For example, composables with unstable parameters become skippable, and lambdas with unstable captures are memoized.
 
-For details, see the [description of Strong Skipping mode](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)
+For details, see the [description of strong skipping mode](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)
 in the Kotlin GitHub repository.
 
 ## What's next

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -142,9 +142,9 @@ you're applying the plugin to.
 There are two kinds of options you can specify:
 
    * General compiler settings.
-   * Feature flags enabling or disabling new and experimental features which eventually should become baseline.
+   * Feature flags that enable or disable new and experimental features, which should eventually become part of the baseline.
 
-An example of such a configuration:
+Here's an example configuration:
 
 ```kotlin
 composeCompiler {
@@ -258,8 +258,8 @@ composeCompiler {
 
 ### Feature flags
 
-Feature flags are separated into their own set to avoid churn of top-level properties as new flags
-are rolled out and deprecated continuously.
+Feature flags are organized into a separate set to minimize changes to top-level properties as new flags
+are continuously rolled out and deprecated.
 
 To enable a feature flag that is disabled by default, specify it in the set, for example:
 
@@ -267,7 +267,7 @@ To enable a feature flag that is disabled by default, specify it in the set, for
 featureFlags = setOf(ComposeFeatureFlag.OptimizeNonSkippingGroups)
 ```
 
-To disable a feature flag that is enabled by default, call the `disabled()` function for it, for example:
+To disable a feature flag that is enabled by default, call the `disabled()` function on it, for example:
 
 ```kotlin
 featureFlags = setOf(ComposeFeatureFlag.StrongSkipping.disabled())
@@ -279,8 +279,7 @@ featureFlags = setOf(ComposeFeatureFlag.StrongSkipping.disabled())
 
 If enabled, turns on intrinsic remember performance optimization.
 
-Intrinsic remember is an optimization mode which inlines `remember` invocations and replaces `.equals` comparisons for keys
-with comparisons of the `$changed` meta parameter when possible.
+Intrinsic remember is an optimization mode that inlines `remember` invocations and, where possible, replaces `.equals` comparisons for keys with comparisons of the `$changed` meta parameter.
 This results in fewer slots being used and fewer comparisons being made at runtime.
 
 #### OptimizeNonSkippingGroups
@@ -294,7 +293,7 @@ unnecessary groups around composables which do not skip (and thus do not require
 This optimization will remove the groups, for example, around functions explicitly marked as `@NonSkippableComposable`
 and functions that are implicitly not skippable (inline functions and functions that return a non-`Unit` value such as `remember`).
 
-> This feature is considered [Experimental](supported-platforms.md#core-kotlin-multiplatform-technology-stability-levels) and is thus disabled by default.
+> This feature is considered [Experimental](supported-platforms.md#core-kotlin-multiplatform-technology-stability-levels) and is disabled by default.
 >
 {type="warning"}
 
@@ -304,12 +303,11 @@ and functions that are implicitly not skippable (inline functions and functions 
 
 If enabled, turns on Strong Skipping mode.
 
-Strong Skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values.
-of composable functions whose parameters haven't changed.
+Strong Skipping mode improves the runtime performance of your application by applying optimizations previously reserved only for stable values of composable functions whose parameters haven't changed.
 For example, composables with unstable parameters become skippable, and lambdas with unstable captures are memoized.
 
 For details, see the [description of Strong Skipping mode](https://github.com/JetBrains/kotlin/blob/master/plugins/compose/design/strong-skipping.md)
-in the Kotlin GitHub repo.
+in the Kotlin GitHub repository.
 
 ## What's next
 


### PR DESCRIPTION
Some options were move to the `featureFlags` set.