### PR TITLE
chore: new EAP version variable

### DIFF
--- a/v.list
+++ b/v.list
@@ -6,7 +6,7 @@
 
     <var name="composeVersion" value="1.6.11" type="string"/>
 
-    <var name="composeEapVersion" value="1.6.10" type="string"/>
+    <var name="composeEapVersion" value="1.7.0-beta01" type="string"/>
 
     <var name="kotlinVersion" value="2.0.0" type="string"/>
 


### PR DESCRIPTION
Not used in master, so updating it ahead of time.