### PR TITLE
fix: visible label names

### DIFF
--- a/labels.list
+++ b/labels.list
@@ -2,14 +2,14 @@
 <labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/stardust/labels.xsd">
 
-    <label short-name="CMP-EAP" full-name="Compose Multiplatform 1.7.0-beta01">
+    <label short-name="EAP" full-name="Compose Multiplatform 1.7.0-beta01">
         This functionality is available only in the EAP version.
     </label>
 
-    <annotation short-name="CMP-Android" full-name="Available in Compose Multiplatform for Android"/>
-    <annotation short-name="CMP-Desktop" full-name="Available in Compose Multiplatform for desktop"/>
-    <annotation short-name="CMP-iOS" full-name="Available in Compose Multiplatform for iOS"/>
-    <annotation short-name="CMP-Web" full-name="Available in Compose Multiplatform for web"/>
+    <annotation short-name="Android" full-name="Available in Compose Multiplatform for Android"/>
+    <annotation short-name="Desktop" full-name="Available in Compose Multiplatform for desktop"/>
+    <annotation short-name="iOS" full-name="Available in Compose Multiplatform for iOS"/>
+    <annotation short-name="Web" full-name="Available in Compose Multiplatform for web"/>
 
     <annotation short-name="Information" full-name="Info" color="blue"/>
     <annotation short-name="Weak warning" full-name="Info" color="tangerine"/>


### PR DESCRIPTION
The short names are not only identifiers, they are also visible in ToC.