### PR TITLE
updated performance numbers

### DIFF
--- a/topics/whats-new/whats-new-compose-170.md
+++ b/topics/whats-new/whats-new-compose-170.md
@@ -327,7 +327,7 @@ paired with Kotlin 2.0.20, we see better results across the board:
 * The *AnimatedVisibility* composable animates showing and hiding an image and demonstrates **~6%** faster rendering.
 
 On top of that, Kotlin 2.0.20 introduces experimental [support for concurrent marking](https://kotlinlang.org/docs/whatsnew2020.html#concurrent-marking-in-garbage-collector) 
-in the garbage collector (GC). Enabling concurrent marking shortens GC pauses and demonstrates even bigger improvements for all benchmarks.
+in the garbage collector. Enabling concurrent marking shortens garbage collector pauses and leads to even bigger improvements for all benchmarks.
 
 You can check out the code for these Compose-specific benchmarks in the Compose Multiplatform repository:
 

--- a/topics/whats-new/whats-new-compose-170.md
+++ b/topics/whats-new/whats-new-compose-170.md
@@ -319,12 +319,15 @@ from Jetpack Compose 1.7.0.
 When comparing Compose Multiplatform 1.6.11 paired with Kotlin 2.0.0 and Compose Multiplatform %composeEapVersion%
 paired with Kotlin 2.0.20, we see better results across the board:
 
-* The *LazyGrid* benchmark simulates `LazyVerticalGrid` scrolling, which is closest to real-life use cases, and performs **~22%** faster on average.
+* The *LazyGrid* benchmark simulates `LazyVerticalGrid` scrolling, which is closest to real-life use cases, and performs **~9%** faster on average.
     It also shows significantly reduced number of missed frames, which usually make the users perceive the UI as less responsive.
     Try it out for yourself: apps made with Compose Multiplatform for iOS should feel much smoother.
-* The *VisualEffects* benchmark renders a lot of randomly placed components and is working **3.6** times faster:
-    average CPU time per 1000 frames is reduced from 8.8 seconds to 2.4.
-* The *AnimatedVisibility* benchmark animates showing and hiding an image and shows **~6%** faster rendering.
+* The *VisualEffects* benchmark renders a lot of randomly placed components and works **3.6** times faster:
+    average CPU time per 1000 frames was reduced from 8.8 seconds to 2.4.
+* The *AnimatedVisibility* composable animates showing and hiding an image and demonstrates **~6%** faster rendering.
+
+On top of that, Kotlin 2.0.20 introduces experimental [support for concurrent marking](https://kotlinlang.org/docs/whatsnew2020.html#concurrent-marking-in-garbage-collector) 
+in the garbage collector (GC). Enabling concurrent marking shortens GC pauses and demonstrates even bigger improvements for all benchmarks.
 
 You can check out the code for these Compose-specific benchmarks in the Compose Multiplatform repository:
 


### PR DESCRIPTION
1. LazyGrid is now only 9% faster
2. Added a little promo of concurrent marking in the garbage collector


