### PR TITLE
fix: fix potential "No virtual method readAllBytes()[B in class Ljava/io/InputStream;" in the implementation of custom "painterResource"

### DIFF
--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -502,7 +502,7 @@ internal fun rememberSvgResource(path: String): Painter {
 
 private object ResourceLoader
 private fun readResourceBytes(resourcePath: String) =
-    ResourceLoader.javaClass.classLoader.getResourceAsStream(resourcePath).readAllBytes()
+    ResourceLoader.javaClass.classLoader?.getResourceAsStream(resourcePath)?.use { it.readBytes() } ?: byteArrayOf()
 ```
 {initial-collapse-state="collapsed" collapsible="true" collapsed-title="internal fun painterResource(resourcePath: String): Painter"}
 


### PR DESCRIPTION
Update the implementation of `readResourceBytes`. 

The original version uses `readAllBytes()`, which is only available after JDK 9. This will cause crash on Android devices whose OS version is lower or equal to 30 (Android 11).