### PR TITLE
web feedback: bumped versions, added imports

### DIFF
--- a/topics/compose/compose-viewmodel.md
+++ b/topics/compose/compose-viewmodel.md
@@ -34,25 +34,27 @@ Using the [navigation example](https://github.com/JetBrains/compose-multiplatfor
 
 1. Declare the ViewModel class:
 
-    ```kotlin
-    class OrderViewModel : ViewModel() {
-        private val _uiState = MutableStateFlow(OrderUiState(pickupOptions = pickupOptions()))
-        val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow()
-   
-        // ...
-    }
-    ```
+```kotlin
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+class OrderViewModel : ViewModel() {
+   private val _uiState = MutableStateFlow(OrderUiState(pickupOptions = pickupOptions()))
+   val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow()
+   // ...
+}
+```
 
 2. Add the ViewModel to your composable function:
 
-    ```kotlin
-    @Composable
-    fun CupcakeApp(
-        viewModel: OrderViewModel = viewModel { OrderViewModel() },
-    ) {
-        // ...
-    }
-    ```
+```kotlin
+@Composable
+fun CupcakeApp(
+   viewModel: OrderViewModel = viewModel { OrderViewModel() },
+) {
+   // ...
+}
+```
 
 > When running coroutines in a `ViewModel`, remember that the `ViewModel.viewModelScope` value is tied to the `Dispatchers.Main.immediate` value,
 > which might be unavailable on desktop by default.

--- a/v.list
+++ b/v.list
@@ -26,8 +26,8 @@
 
     <var name="kmpncVersion" value="1.0.0-ALPHA-33" type="string"/>
 
-    <var name="composeNavigationVersion" value="2.7.0-alpha07" type="string"/>
+    <var name="composeNavigationVersion" value="2.8.0-alpha10" type="string"/>
 
-    <var name="composeViewmodelVersion" value="2.8.0" type="string"/>
+    <var name="composeViewmodelVersion" value="2.8.2" type="string"/>
 
 </vars>


### PR DESCRIPTION
- [KWHF-1764](https://youtrack.jetbrains.com/issue/KWHF-1764/Web-feedback-from-Common-ViewModel-https-www.jetbrains.com-help-kotlin-multiplatform-dev-compose-viewmodel.html) Someone couldn't find the required imports, and there are more affected users on stackoverflow. I think it won't hurt to show key imports.
- [KWHF-1774](https://youtrack.jetbrains.com/issue/KWHF-1774/Web-feedback-from-Navigation-and-routing-https-www.jetbrains.com-help-kotlin-multiplatform-dev-compose-navigation-routing.html) Updated libs versions.