### PR TITLE
Update onClick description to reflect the code

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-explore-composables.md
+++ b/topics/compose-onboard/compose-multiplatform-explore-composables.md
@@ -77,9 +77,8 @@ When the value of the state changes, any composables that observe it are re-invo
 produce to be redrawn. This is called a _recomposition_.
 
 In your application, the only place where the state is changed is in the click event of the button. The `onClick` event
-handler flips the value of the `showContent` property and invokes the `greeting` property with the platform name.
-
-The changes occur when the image is shown or hidden because the parent `AnimatedVisibility` composable observes `showContent`.
+handler flips the value of the `showContent` property. As a result, the image gets shown or hidden
+because the parent `AnimatedVisibility` composable observes `showContent`.
 
 ## Launching UI on different platforms
 


### PR DESCRIPTION
The `onClick` event handler does not invoke the greeting property  with the platform name.