### PR TITLE
fix: mention Res import explicitly

### DIFF
--- a/topics/compose/compose-multiplatform-resources-setup.md
+++ b/topics/compose/compose-multiplatform-resources-setup.md
@@ -35,7 +35,8 @@ To access resources in your multiplatform projects, add the library dependency a
 
 3. Organize the `composeResources` directory structure according to these rules:
 
-   * Images should be in the `drawable` directory.
+   * Images should be in the `drawable` directory. Compose Multiplatform supports rasterized images (JPEG, PNG, bitmap, and WebP)
+     and vector Android XML images (without references to Android resources).
    * Fonts should be in the `font` directory.
    * Strings should be in the `values` directory.
    * Other files should be in the `files` directory, with any folder hierarchy you may find appropriate.

--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -8,6 +8,21 @@ To regenerate the `Res` class and all the resource accessors, build the project 
 
 After that, you can use the generated class to access the configured multiplatform resources from your code or from external libraries.
 
+## Importing the generated class
+
+To use the prepared resources, import the generated class, for example:
+
+```Kotlin
+import project.composeapp.generated.resources.Res
+import project.composeapp.generated.resources.example_image
+```
+
+Here:
+* `project` is the name of your project
+* `composeapp` is the module where you placed the resource directories
+* `Res` is the default name for the generated class
+* `example_image` is the name of an image file in the `composeResources/drawable` directory (`example_image.png`, for example).
+
 ## Customizing accessor class generation
 
 You can customize the generated `Res` class to suit your needs using Gradle settings.

--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -12,7 +12,7 @@ After that, you can use the generated class to access the configured multiplatfo
 
 To use the prepared resources, import the generated class, for example:
 
-```Kotlin
+```kotlin
 import project.composeapp.generated.resources.Res
 import project.composeapp.generated.resources.example_image
 ```


### PR DESCRIPTION
In the course of expanding the resources documentation we lost the explicit mention of the way users need to import the generated class when they add Compose Multiplatform to an existing project.