### PR TITLE
fix: clearer explanation of string templates

### DIFF
--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -1,6 +1,6 @@
 [//]: # (title: Using multiplatform resources in your app)
 
-<toc-settings structure-elements="chapter" depth="3"/>
+<show-structure depth="2"/>
 
 When you've [set up the resources for your project](compose-multiplatform-resources-setup.md),
 build the project to generate the special `Res` class which provides access to resources.

--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -178,7 +178,7 @@ Text(stringResource(Res.string.str_template, 100, "User_name"))
 ```
 
 There is no difference between `$s` and `$d` suffixes, and no others are supported.
-You can provide the placeholder `%1$s` and use it to display a fractional number, for example:
+You can put the `%1$s` placeholder in the resource string and use it to display a fractional number, for example:
 
 ```kotlin
 Text(stringResource(Res.string.str_template, "User_name", 100.1f))

--- a/topics/compose/compose-multiplatform-resources-usage.md
+++ b/topics/compose/compose-multiplatform-resources-usage.md
@@ -154,21 +154,34 @@ You can use special symbols in string resources:
 * `\t` — for a tab symbol
 * `\uXXXX` — for a specific Unicode character
 
+You don't need to escape special XML characters like "@" or "?"
+as you do [for Android strings](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes). 
+
 #### String templates
 
-Currently, arguments have basic support in string resources:
+Currently, arguments have basic support for string resources.
+When creating a template, use the `%<number>` format for placing arguments within the string and a `$d` or a `$s` suffix
+to signal that it's a variable placeholder and not simple text.
+For example:
 
 ```XML
 <resources>
-    <string name="str_template">Hello, %1$s! You have %2$d new messages.</string>
+    <string name="str_template">Hello, %2$s! You have %1$d new messages.</string>
 </resources>
 ```
 
-There is no difference between `%...s` and `%...d ` when using string templates with arguments from composable code,
-for example:
+After creating and importing the string template resource, you can refer to it while
+passing the arguments for placeholders in the correct order:
 
 ```kotlin
-Text(stringResource(Res.string.str_template, "User_name", 100))
+Text(stringResource(Res.string.str_template, 100, "User_name"))
+```
+
+There is no difference between `$s` and `$d` suffixes, and no others are supported.
+You can provide the placeholder `%1$s` and use it to display a fractional number, for example:
+
+```kotlin
+Text(stringResource(Res.string.str_template, "User_name", 100.1f))
 ```
 
 #### String arrays


### PR DESCRIPTION
For [CMP-7097](https://youtrack.jetbrains.com/issue/CMP-7097/Compose-multiplatform-resources-documentation-doesnt-explain-differences-with-Android). It should be clearer how multiplatform resources are different from [Android string formatting](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes).