### PR TITLE
update: note on older AGP version

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-create-first-app.md
+++ b/topics/compose-onboard/compose-multiplatform-create-first-app.md
@@ -58,8 +58,13 @@ To begin, create a sample project. This is best achieved with the Kotlin Multipl
 3. Navigate to the unpacked "ComposeDemo" folder and then click **Open**.
 
    Android Studio detects that the folder contains a Gradle build file and opens the folder as a new project.
-
    If you didn't select iOS in the wizard, you won't have the folders whose names begin with "ios" or "apple".
+
+    > Android Studio may automatically suggest upgrading the Android Gradle plugin in the project to the latest version.
+    > We don't recommend upgrading as Kotlin Multiplatform is not compatible with the latest AGP version
+    > (see the [compatibility table](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility)).
+    >
+    {style="note"}
 
 4. The default view in Android Studio is optimized for Android development. To see the full file structure of the project,
    which is more convenient for multiplatform development, switch the view from **Android** to **Project**:

--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -48,8 +48,9 @@ The following instructions assume that you have all software necessary for the p
 
    Android Studio detects that the folder contains a Gradle build file and opens the folder as a new project.
 
-   > Since the Android Gradle plugin support in Kotlin Multiplatform is a little [behind the latest version](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility)
-   > it is **not** recommended to automatically upgrade AGP whenever Android Studio suggests it.
+   > Android Studio may automatically suggest upgrading the Android Gradle plugin in the project to the latest version.
+   > We don't recommend upgrading as Kotlin Multiplatform is not compatible with the latest AGP version
+   > (see the [compatibility table](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility)).
    >
    {style="note"}
 

--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -48,6 +48,11 @@ The following instructions assume that you have all software necessary for the p
 
    Android Studio detects that the folder contains a Gradle build file and opens the folder as a new project.
 
+   > Since the Android Gradle plugin support in Kotlin Multiplatform is a little [behind the latest version](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility)
+   > it is **not** recommended to automatically upgrade AGP whenever Android Studio suggests it.
+   >
+   {style="note"}
+
 4. The default view in Android Studio is optimized for Android development. To see the full file structure of the project,
    which is more convenient for multiplatform development, switch the view from **Android** to **Project**:
 


### PR DESCRIPTION
Some users automatically upgrade AGP when Android Studio suggests it, and then the wizard-generated project may not work anymore. Since this will continue to happen until KMP supports the latest AGP, a warning about this doesn't seem out of place.