### PR TITLE
fix: more transparent code sample

### DIFF
--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -105,7 +105,7 @@ the IDE will show a warning:
 2. Follow the IDE's suggestions and replace it with `kotlin.random.Random` from the Kotlin standard library.
    This is a multiplatform library that works on all platforms and is included automatically as a dependency.
 3. Remove brackets from `Random()`, as it is an abstract class. The code should now compile successfully.
-4. Add a bit of variety to the greeting. Update the shared code with the `reversed()` function
+4. Add a bit of variety to the greeting. Update the shared code with the `reversed()` call
    from the Kotlin standard library to reverse the text:
 
     ```kotlin

--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -90,10 +90,13 @@ the IDE will show a warning:
    ```kotlin
    import java.util.Random
    
-   fun greet(): String {
-       val firstWord = if (Random().nextBoolean()) "Hi!" else "Hello!"
+   class Greeting {
+       // ...
+       fun greet(): String {
+           val firstWord = if (Random().nextBoolean()) "Hi!" else "Hello!"
    
-       return firstWord
+           return firstWord
+       }
    }
    ```
 

--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -91,7 +91,8 @@ the IDE will show a warning:
    import java.util.Random
    
    class Greeting {
-       // ...
+       private val platform: Platform = getPlatform()
+   
        fun greet(): String {
            val firstWord = if (Random().nextBoolean()) "Hi!" else "Hello!"
    


### PR DESCRIPTION
The two code samples about the same piece of code are misaligned. If a reader is not familiar with import directives in Kotlin, they may be confused as to where `import java.util.Random` is supposed to go.