### PR TITLE
Update iOS stability level to Stable

### DIFF
--- a/topics/overview/supported-platforms.md
+++ b/topics/overview/supported-platforms.md
@@ -83,7 +83,7 @@ We refer to **Experimental**, **Alpha**, and **Beta** collectively as **pre-stab
 | Platform                 | Stability level |
 |--------------------------|-----------------|
 | Android                  | Stable          |
-| iOS                      | Beta            |
+| iOS                      | Stable          |
 | Desktop (JVM)            | Stable          |
 | Web based on Kotlin/Wasm | Alpha           |
 


### PR DESCRIPTION
### Changes
- Updated the iOS stability level from Beta to Stable in the platform support table.

### Reason
- Reflecting the latest stability status of iOS support in Compose Multiplatform.
