### PR TITLE
Swap tiles in Get started

### DIFF
--- a/topics/overview/get-started.topic
+++ b/topics/overview/get-started.topic
@@ -12,8 +12,8 @@
             Share a UI with Compose Multiplatform or keep it native? Start from scratch or migrate from an existing Android app? Do it your way!
         </description>
         <spotlight>
-            <a href="multiplatform-create-first-app.md" summary="Create your first Kotlin Multiplatform app with a native UI for Android (Jetpack Compose UI) and iOS (SwiftUI)" type="turn-on">Share logic and keep UI native</a>
             <a href="compose-multiplatform-create-first-app.md" summary="Create your first Compose Multiplatform app with a shared UI across Android, iOS, and desktop" type="cross-platform">Share both logic and UI</a>
+            <a href="multiplatform-create-first-app.md" summary="Create your first Kotlin Multiplatform app with a native UI for Android (Jetpack Compose UI) and iOS (SwiftUI)" type="turn-on">Share logic and keep UI native</a>
         </spotlight>
         <primary>
             <title>Migration</title>


### PR DESCRIPTION
This PR makes the Shared UI tutorial take first place on the Get started page.