### PR TITLE
CMP tutorial: Small update to time instructions

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-modify-project.md
+++ b/topics/compose-onboard/compose-multiplatform-modify-project.md
@@ -115,7 +115,7 @@ To use the `kotlinx-datetime` library:
     ```
 
 3. Follow the IDE's suggestions to import the missing dependencies.
-   Make sure to import `Clock` from `kotlinx-datetime`, not `kotlin.time`.
+   Make sure to import all the missing dependencies for the `todaysDate()` function from the `kotlinx.datetime` package, **NOT** `kotlin.time`.
 
    ![Unresolved references](compose-unresolved-references.png)
 


### PR DESCRIPTION
This PR updates the CMP tutorial to clarify that all dependencies for the `todaysDate()` function need to be taken from the `kotlinx.datetime` package and not `kotlin.time`.