### PR TITLE
update iOS compose stability in FAQ

### DIFF
--- a/topics/overview/faq.md
+++ b/topics/overview/faq.md
@@ -122,7 +122,7 @@ For details, see the [overview of the frameworks' interrelation](compose-multipl
 ### Between which platforms can I share my UI?
 
 We want you to have the option to share your UI between any combination of popular platforms – Android, iOS, desktop
-(Linux, macOS, Windows), and web (based on Wasm). However, Compose Multiplatform is only Stable for Android
+(Linux, macOS, Windows), and web (based on Wasm). Compose Multiplatform is only Stable for Android, iOS,
 and desktop at the moment. For more details, see [Supported platforms](supported-platforms.md).
 
 ### Can I use Compose Multiplatform in production?


### PR DESCRIPTION
Was just reading through the docs and noticed that it currently mentions that `Compose Multiplatform is only Stable for Android and desktop at the moment`. iOS was recently made stable, hence, I'm updating this line.

https://www.jetbrains.com/help/kotlin-multiplatform-dev/faq.html#between-which-platforms-can-i-share-my-ui

