### PR TITLE
Link wasm tutorial to CMP tutorial

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-new-project.md
+++ b/topics/compose-onboard/compose-multiplatform-new-project.md
@@ -527,6 +527,7 @@ We encourage you to explore multiplatform development further and try out more p
 * [Make your Android app cross-platform](multiplatform-integrate-in-existing-app.md)
 * [Create a multiplatform app using Ktor and SQLDelight](multiplatform-ktor-sqldelight.md)
 * [Share business logic between iOS and Android while keeping the UI native](multiplatform-create-first-app.md)
+* [Create a Compose Multiplatform app with Kotlin/Wasm](https://kotlinlang.org/docs/wasm-get-started.html)
 * [See the curated list of sample projects](multiplatform-samples.md)
 
 Join the community:


### PR DESCRIPTION
This PR adds a link to the Get started with Kotlin/Wasm tutorial as a next step after completing the CMP tutorial.

Related PR: https://github.com/JetBrains/kotlin-web-site/pull/4955