### PR TITLE
update: native crash reports

### DIFF
--- a/topics/multiplatform-publish-apps.md
+++ b/topics/multiplatform-publish-apps.md
@@ -77,9 +77,7 @@ such as functions or line numbers.
 By default, the release versions of iOS frameworks produced from the shared Kotlin module have an accompanying `.dSYM`
 file. This helps you analyze crashes that happen in the shared module's code.
 
-When an iOS app is rebuilt from bitcode, its `dSYM` file becomes invalid. For such cases, you can compile the shared module
-to a static framework that stores the debug information inside itself. For instructions on setting up crash report
-symbolication in binaries produced from Kotlin modules, see the [Kotlin/Native documentation](https://kotlinlang.org/docs/native-ios-symbolication.html).
+For more information on crash report symbolication, see the [Kotlin/Native documentation](https://kotlinlang.org/docs/native-debugging.html##debug-ios-applications).
 
 ## Web app
 

--- a/topics/multiplatform-publish-apps.md
+++ b/topics/multiplatform-publish-apps.md
@@ -77,7 +77,7 @@ such as functions or line numbers.
 By default, the release versions of iOS frameworks produced from the shared Kotlin module have an accompanying `.dSYM`
 file. This helps you analyze crashes that happen in the shared module's code.
 
-For more information on crash report symbolication, see the [Kotlin/Native documentation](https://kotlinlang.org/docs/native-debugging.html##debug-ios-applications).
+For more information on crash report symbolication, see the [Kotlin/Native documentation](https://kotlinlang.org/docs/native-debugging.html#debug-ios-applications).
 
 ## Web app
 


### PR DESCRIPTION
This PR updates the crash reports section following the removal of the bitcode part in [#4962](https://github.com/JetBrains/kotlin-web-site/pull/4962)