### PR TITLE
Remove link to dependencies at top level section

### DIFF
--- a/topics/development/multiplatform-add-dependencies.md
+++ b/topics/development/multiplatform-add-dependencies.md
@@ -40,8 +40,6 @@ kotlin {
 </tab>
 </tabs>
 
-Alternatively, you can [set dependencies at the top level](https://kotlinlang.org/docs/gradle-configure-project.html#set-dependencies-at-top-level).
-
 ## Dependency on a Kotlin library
 
 ### Standard library


### PR DESCRIPTION
This PR removes the link to the section about declaring top-level dependencies that has been removed.