### PR TITLE
Add top-level dependencies block for Kotlin 2.2.20

### DIFF
--- a/topics/development/multiplatform-add-dependencies.md
+++ b/topics/development/multiplatform-add-dependencies.md
@@ -178,7 +178,7 @@ their dependencies to your project.
 ### Library shared for all source sets
 
 If you want to use a library from all source sets, you can add it only to the common source set. The Kotlin
-Multiplatform Mobile plugin will automatically add the corresponding parts to any other source sets.
+Multiplatform plugin automatically adds the corresponding parts to any other source sets.
 
 > You cannot set dependencies on platform-specific libraries in the common source set.
 >
@@ -224,6 +224,10 @@ kotlin {
 
 </tab>
 </tabs>
+
+> You can also configure a common library in a top-level `dependencies {}` block. See [Configure dependencies at the top level](multiplatform-dsl-reference.md#configure-dependencies-at-the-top-level).
+> 
+{style="tip"}
 
 ### Library used in specific source sets
 

--- a/topics/tools/multiplatform-dsl-reference.md
+++ b/topics/tools/multiplatform-dsl-reference.md
@@ -36,12 +36,13 @@ plugins {
 `kotlin {}` is the top-level block for multiplatform project configuration in the Gradle build script.
 Inside `kotlin {}`, you can write the following blocks:
 
-| **Block**            | **Description**                                                                                                                          |
-|----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| _&lt;targetName&gt;_ | Declares a particular target of a project. The names of available targets are listed in the [Targets](#targets) section.                 |
-| `targets`            | Lists all targets of the project.                                                                                                        |
-| `sourceSets`         | Configures predefined and declares custom [source sets](#source-sets) of the project.                                                    |
+| **Block**            | **Description**                                                                                                                         |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| _&lt;targetName&gt;_ | Declares a particular target of a project. The names of available targets are listed in the [Targets](#targets) section.                |
+| `targets`            | Lists all targets of the project.                                                                                                       |
+| `sourceSets`         | Configures predefined and declares custom [source sets](#source-sets) of the project.                                                   |
 | `compilerOptions`    | Specifies common extension-level [compiler options](#compiler-options) that are used as defaults for all targets and shared source sets. |
+| `dependencies`       | Configures [common dependencies](#configure-dependencies-at-the-top-level). (Experimental)                                              |
 
 ## Targets
 
@@ -1001,6 +1002,45 @@ kotlin {
 
 Additionally, source sets can depend on each other and form a hierarchy.
 In this case, the [`dependsOn()`](#source-set-parameters) relation is used.
+
+### Configure dependencies at the top level
+<secondary-label ref="Experimental"/>
+
+You can configure common dependencies using a top-level `dependencies {}` block. Dependencies declared here behave as if
+they were added to the `commonMain` or `commonTest` source sets.
+
+To use the top-level `dependencies {}` block, opt in by adding the `@OptIn(ExperimentalKotlinGradlePluginApi::class)`
+annotation before the block:
+
+<tabs group="build-script">
+<tab title="Kotlin" group-key="kotlin">
+
+```kotlin
+kotlin {
+    @OptIn(ExperimentalKotlinGradlePluginApi::class)
+    dependencies {
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%")
+    }
+}
+```
+
+</tab>
+<tab title="Groovy" group-key="groovy">
+
+```groovy
+kotlin {
+    dependencies {
+        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:%coroutinesVersion%'
+    }
+}
+```
+
+</tab>
+</tabs>
+
+Add platform-specific dependencies inside the `sourceSets {}` block of the corresponding target.
+
+You can share your feedback on this feature in [YouTrack](https://youtrack.jetbrains.com/issue/KT-76446).
 
 ## Language settings
 


### PR DESCRIPTION
This PR adds details about the experimental top-level dependencies block introduced in Kotlin 2.2.20.