### PR TITLE
Update wrs-supernova to temove the duplication of the last-modified-date

### DIFF
--- a/writerside.cfg
+++ b/writerside.cfg
@@ -9,7 +9,7 @@
     <vars src="v.list"/>
 
     <settings>
-        <wrs-supernova use-version="2.1.1991-p6895"/>
+        <wrs-supernova use-version="2025.07.8502"/>
     </settings>
     <instance src="mpd.tree" id="kotlin-multiplatform-dev" keymaps-mode="provided"
               web-path="/kotlin-multiplatform-dev/"/>


### PR DESCRIPTION
Removes the duplication of the last-modified-date: `Last modified: Last modified: 16 May 2025`