### PR TITLE
feat: Kotlin 2.3.21 release

### DIFF
--- a/topics/development/multiplatform-compatibility-guide.md
+++ b/topics/development/multiplatform-compatibility-guide.md
@@ -24,21 +24,21 @@ the Kotlin version you have in your projects, for example:
 When configuring your project, check the compatibility of a particular version of the Kotlin Multiplatform Gradle plugin
 (same as the Kotlin version in your project) with Gradle, Xcode, and Android Gradle plugin versions:
 
-| Kotlin Multiplatform plugin version | Gradle                                 | Android Gradle plugin                               | Xcode   |
-|-------------------------------------|----------------------------------------|-----------------------------------------------------|---------|
-| 2.3.20                              | %minGradleVersion%–%maxGradleVersion%  | %minAndroidGradleVersion%–%maxAndroidGradleVersion% | %xcode% |
-| 2.3.10                              | 7.6.3–9.0.0                            | 8.2.2–9.0.0                                         | 26.0    |
-| 2.3.0                               | 7.6.3–9.0.0                            | 8.2.2–8.13.0                                        | 26.0    |
-| 2.2.21                              | 7.6.3–8.14                             | 7.3.1–8.11.1                                        | 26.0    |
-| 2.2.20                              | 7.6.3–8.14                             | 7.3.1–8.11.1                                        | 16.4    |
-| 2.2.0-2.2.10                        | 7.6.3–8.14                             | 7.3.1–8.10.0                                        | 16.3    |
-| 2.1.21                              | 7.6.3–8.12.1                           | 7.3.1–8.7.2                                         | 16.3    |
-| 2.1.20                              | 7.6.3–8.11                             | 7.4.2–8.7.2                                         | 16.0    |
-| 2.1.0–2.1.10                        | 7.6.3-8.10*                            | 7.4.2–8.7.2                                         | 16.0    |
-| 2.0.21                              | 7.5-8.8*                               | 7.4.2–8.5                                           | 16.0    |
-| 2.0.20                              | 7.5-8.8*                               | 7.4.2–8.5                                           | 15.3    |
-| 2.0.0                               | 7.5-8.5                                | 7.4.2–8.3                                           | 15.3    |
-| 1.9.20                              | 7.5-8.1.1                              | 7.4.2–8.2                                           | 15.0    |
+| Kotlin Multiplatform plugin version | Gradle                                | Android Gradle plugin                               | Xcode   |
+|-------------------------------------|---------------------------------------|-----------------------------------------------------|---------|
+| 2.3.20–2.3.21                       | %minGradleVersion%–%maxGradleVersion% | %minAndroidGradleVersion%–%maxAndroidGradleVersion% | %xcode% |
+| 2.3.10                              | 7.6.3–9.0.0                           | 8.2.2–9.0.0                                         | 26.0    |
+| 2.3.0                               | 7.6.3–9.0.0                           | 8.2.2–8.13.0                                        | 26.0    |
+| 2.2.21                              | 7.6.3–8.14                            | 7.3.1–8.11.1                                        | 26.0    |
+| 2.2.20                              | 7.6.3–8.14                            | 7.3.1–8.11.1                                        | 16.4    |
+| 2.2.0–2.2.10                        | 7.6.3–8.14                            | 7.3.1–8.10.0                                        | 16.3    |
+| 2.1.21                              | 7.6.3–8.12.1                          | 7.3.1–8.7.2                                         | 16.3    |
+| 2.1.20                              | 7.6.3–8.11                            | 7.4.2–8.7.2                                         | 16.0    |
+| 2.1.0–2.1.10                        | 7.6.3-8.10*                           | 7.4.2–8.7.2                                         | 16.0    |
+| 2.0.21                              | 7.5-8.8*                              | 7.4.2–8.5                                           | 16.0    |
+| 2.0.20                              | 7.5-8.8*                              | 7.4.2–8.5                                           | 15.3    |
+| 2.0.0                               | 7.5-8.5                               | 7.4.2–8.3                                           | 15.3    |
+| 1.9.20                              | 7.5-8.1.1                             | 7.4.2–8.2                                           | 15.0    |
 
 > *Kotlin 2.0.20–2.0.21 and Kotlin 2.1.0–2.1.10 are fully compatible with Gradle up to 8.6.
 > Gradle versions 8.7–8.10 are also supported, with only one exception: If you use the Kotlin Multiplatform Gradle plugin,

--- a/v.list
+++ b/v.list
@@ -4,9 +4,9 @@
 
 <vars>
     <!-- Kotlin -->
-    <var name="kotlinVersion" value="2.3.20"/>
+    <var name="kotlinVersion" value="2.3.21"/>
     <var name="kotlinEapVersion" value="2.4.0-Beta2"/>
-    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.3.20"/>
+    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.3.21"/>
     <var name="kmpLatestUrl" value="https://github.com/JetBrains/compose-multiplatform/releases"/>
     <var name="languageVersion" value="2.3"/>
     <var name="apiVersion" value="2.3"/>


### PR DESCRIPTION
This PR includes information about the Kotlin 2.3.21 release.