### PR TITLE
fix: link 'Get started' image to KMP getting started page

### DIFF
--- a/topics/journal/multiplatform-reasons-to-try.md
+++ b/topics/journal/multiplatform-reasons-to-try.md
@@ -82,7 +82,7 @@ Here's how using KMP benefited the Quizlet team:
 * Enhanced developer experience.
 * Increased interest from team members, including Android, iOS, backend, and web developers, in writing shared code.
 
-![Get started with Kotlin Multiplatform](get-started-with-kmp.svg){width="500"}
+[![Get started with Kotlin Multiplatform](get-started-with-kmp.svg){width="500"}](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)
 
 ### 3. Kotlin provides simplified code-sharing mechanisms
 

--- a/topics/journal/multiplatform-reasons-to-try.md
+++ b/topics/journal/multiplatform-reasons-to-try.md
@@ -58,7 +58,7 @@ The experiment turned out to be very successful, resulting in the following:
 * A reduction in their maintenance and testing costs.
 * Significantly improved productivity within the team.
 
-[![Explore real-world Kotlin Multiplatform use cases](kmp-use-cases-1.svg){width="500"}](https://www.jetbrains.com/help/kotlin-multiplatform-dev/case-studies.html)
+[![Explore real-world Kotlin Multiplatform use cases](kmp-use-cases-1.svg){width="500"}](https://kotlinlang.org/case-studies/)
 
 ### 2. Kotlin Multiplatform supports an extensive list of platforms
 
@@ -82,7 +82,7 @@ Here's how using KMP benefited the Quizlet team:
 * Enhanced developer experience.
 * Increased interest from team members, including Android, iOS, backend, and web developers, in writing shared code.
 
-[![Get started with Kotlin Multiplatform](get-started-with-kmp.svg){width="500"}](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)
+[![Get started with Kotlin Multiplatform](get-started-with-kmp.svg){width="500"}](get-started.topic)
 
 ### 3. Kotlin provides simplified code-sharing mechanisms
 


### PR DESCRIPTION
## What
  Makes the "Get started with Kotlin Multiplatform" image in
  `topics/journal/multiplatform-reasons-to-try.md` clickable, linking to the
  official Get started page.

  ## Why
  The image was not actionable — readers couldn't navigate to the Get started
  page from it. The other "Get started" images in this file (line 248) and across
  the repo already link to the same destination.

  ## Target URL
  https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html
  (consistent with `cross-platform-mobile-development.md`,
  `cross-platform-frameworks.md`, `native-and-cross-platform.md`, and line 248
  of the same file)

  ## Checklist
  - [x] Followed the style guide
  - [x] Single-line change, no formatting/tree changes
  - [x] Verified link target and consistency with existing usage