### PR TITLE
Add missing kotlin block to agp9 migration step

### DIFF
--- a/topics/development/multiplatform-project-agp-9-migration.md
+++ b/topics/development/multiplatform-project-agp-9-migration.md
@@ -149,9 +149,11 @@ Configure the Gradle build script for the new module:
    the `target {}` block of the `androidApp/build.gradle.kts` file:
 
     ```kotlin
-    target {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+    kotlin {
+        target {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_11)
+            }
         }
     }
     ```


### PR DESCRIPTION
This PR fixes KEDOC-244.