### PR TITLE
fix: tweaks and mistakes in the native UI tutorial chain

### DIFF
--- a/topics/compose-onboard/compose-multiplatform-modify-project.md
+++ b/topics/compose-onboard/compose-multiplatform-modify-project.md
@@ -33,7 +33,7 @@ To use the `kotlinx-datetime` library:
 
 1. Open the `gradle/libs.versions.toml` file and add the `kotlinx-datetime` dependency to the version catalog:
 
-    ```text
+    ```toml
     [versions]
     kotlinx-datetime = "0.8.0"
     

--- a/topics/compose/compose-compiler.md
+++ b/topics/compose/compose-compiler.md
@@ -30,7 +30,7 @@ module that uses the `org.jetbrains.compose` plugin:
 
 1. Add the Compose compiler Gradle plugin to the [Gradle version catalog](https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml):
 
-    ```
+    ```toml
     [versions]
     # ...
     kotlin = "%kotlinVersion%"

--- a/topics/compose/compose-navigation-3.md
+++ b/topics/compose/compose-navigation-3.md
@@ -25,7 +25,7 @@ Learn more about general design of Navigation 3 in [Android documentation](https
 
 To try out the multiplatform implementation of Navigation 3, add the following dependency to your version catalog:
 
-```text
+```toml
 [versions]
 multiplatform-nav3-ui = "1.0.0-alpha05"
 
@@ -40,7 +40,7 @@ jetbrains-navigation3-ui = { module = "org.jetbrains.androidx.navigation3:naviga
 {style="note"}
 
 For projects using the Material 3 Adaptive and ViewModel libraries, also add the following navigation support artifacts:
-```text
+```toml
 [versions]
 compose-multiplatform-adaptive = "1.3.0-alpha02"
 compose-multiplatform-lifecycle = "2.10.0-alpha05"
@@ -53,7 +53,7 @@ jetbrains-lifecycle-viewmodelNavigation3 = { module = "org.jetbrains.androidx.li
 Finally, you can try out the [proof-of-concept library](https://github.com/terrakok/navigation3-browser)
 created by a JetBrains engineer. The library integrates the multiplatform Navigation 3 with browser history navigation on the web:
 
-```text
+```toml
 [versions]
 compose-multiplatform-navigation3-browser = "0.2.0"
 

--- a/topics/compose/compose-navigation-deep-links.md
+++ b/topics/compose/compose-navigation-deep-links.md
@@ -29,7 +29,7 @@ To use deep links with Compose Multiplatform, set up the dependencies as follows
 
 List these versions, libraries, and plugins in your Gradle catalog:
 
-```ini
+```toml
 [versions]
 compose-multiplatform = "%org.jetbrains.compose%"
 agp = "8.9.0"

--- a/topics/development/multiplatform-cocoapods-overview.md
+++ b/topics/development/multiplatform-cocoapods-overview.md
@@ -111,10 +111,11 @@ The following steps show the configuration on a freshly generated project:
 1. Generate a new project for Android and iOS using the [Kotlin Multiplatform IDE plugin](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform)
    or the [Kotlin Multiplatform web wizard](https://kmp.jetbrains.com).
    If using the web wizard, unpack the archive and import the project in your IDE.
-2. In the `gradle/libs.versions.toml` file, add the Kotlin CocoaPods Gradle plugin to 
-   the `[plugins]` block:
+2. Add the Kotlin CocoaPods Gradle plugin to the version catalog
+   (the `gradle/libs.versions.toml` file):
 
-   ```text
+   ```toml
+   [plugins]
    kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
    ```
 

--- a/topics/development/multiplatform-ktor-sqldelight.md
+++ b/topics/development/multiplatform-ktor-sqldelight.md
@@ -64,11 +64,11 @@ Change or add lines in the version catalog in the `gradle/libs.versions.toml` fi
 
 1. In the `[versions]` block, check the AGP version and add the rest:
 
-   ```text
+   ```toml
    [versions]
    agp = "9.0.1"
    material3 = "1.11.0-alpha07"
-   ...
+   # ...
    coroutinesVersion = "%coroutinesVersion%"
    dateTimeVersion = "%dateTimeVersion%"
    koin = "%koinVersion%"

--- a/topics/development/multiplatform-ktor-sqldelight.md
+++ b/topics/development/multiplatform-ktor-sqldelight.md
@@ -99,9 +99,9 @@ Change or add lines in the version catalog in the `gradle/libs.versions.toml` fi
 
 3. In the `[plugins]` block, specify the necessary Gradle plugins:
 
-   ```
+   ```toml
    [plugins]
-   ...
+   # ...
    kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
    sqldelight = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
    ```

--- a/topics/development/multiplatform-project-agp-9-migration.md
+++ b/topics/development/multiplatform-project-agp-9-migration.md
@@ -96,7 +96,7 @@ Configure the Gradle build script for the new module:
 
 1. In the `gradle/libs.versions.toml` file, add the Kotlin Android Gradle plugin to your version catalog:
 
-    ```text
+    ```toml
     [plugins]
     kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
     ```
@@ -228,7 +228,7 @@ Now migrate to the new multiplatform library plugin:
 1. In `gradle/libs.versions.toml`,
    add the Android-KMP library plugin to your version catalog:
 
-    ```text
+    ```toml
     [plugins]
     androidMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
     ```

--- a/topics/development/multiplatform-project-agp-9-migration.md
+++ b/topics/development/multiplatform-project-agp-9-migration.md
@@ -280,7 +280,7 @@ When all of your code works with the new configuration:
       You can delete obsolete run configurations associated with the `composeApp` module.
 2. In the `gradle/libs.versions.toml` file, update the AGP to a 9.* version, for example:
 
-    ```text
+    ```toml
     [versions]
     agp = "9.0.0"
     ```

--- a/topics/development/multiplatform-project-recommended-structure.md
+++ b/topics/development/multiplatform-project-recommended-structure.md
@@ -69,7 +69,7 @@ To make the desktop app build script work:
 
 1. In the `gradle/libs.versions.toml` file, add the Kotlin JVM Gradle plugin to your version catalog:
 
-    ```text
+    ```toml
     [plugins]
     kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
     ```
@@ -260,7 +260,7 @@ Here are the necessary changes:
 1. In `gradle/libs.versions.toml`,
    add the Android-KMP library plugin to your version catalog:
 
-    ```text
+    ```toml
     [plugins]
     androidMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
     ```
@@ -335,7 +335,7 @@ Isolate the corresponding code in a `sharedLogic` module:
 
     1. In the `gradle/libs.versions.toml` file, add the Android-KMP library plugin to your version catalog:
 
-        ```text
+        ```toml
         [plugins]
         androidMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
         ```
@@ -448,7 +448,7 @@ Extract shared code implementing common UI elements in the `sharedUI` module:
     1. If you haven't done this for the `sharedLogic` module, in `gradle/libs.versions.toml`,
        add the Android-KMP library plugin to your version catalog:
 
-        ```text
+        ```toml
         [plugins]
         androidMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
         ```

--- a/topics/development/multiplatform-spm-import.md
+++ b/topics/development/multiplatform-spm-import.md
@@ -36,7 +36,7 @@ To try out the SwiftPM import functionality, make sure that you are using the **
 of the Kotlin Multiplatform Gradle plugin.
 Example for a `gradle/libs.versions.toml` file:
 
-```text
+```toml
 [versions]
 kotlin = "%kotlinEapVersion%"
 

--- a/topics/multiplatform-onboard/multiplatform-create-first-app.md
+++ b/topics/multiplatform-onboard/multiplatform-create-first-app.md
@@ -50,26 +50,25 @@ In IntelliJ IDEA, expand the `GreetingKMP` folder.
 
 This Kotlin Multiplatform project includes the following modules:
 
-* _androidApp_ is a Kotlin module that builds into an Android application. It uses Gradle as the build system.
-  The composeApp module depends on and uses the shared module as a regular Android library.
-* _iosApp_ is an Xcode project that builds into an iOS application.
+* `androidApp` is a Kotlin module that builds into an Android application. It uses Gradle as the build system.
+  The `androidApp` module depends on and uses the shared module as a regular Android library.
+* `iosApp` is an Xcode project that builds into an iOS application.
   It depends on the `sharedLogic` module, which is exported as an iOS framework.
   Kotlin Multiplatform projects created using the IDE wizard use the regular framework dependency through
   [direct integration](multiplatform-direct-integration.md).
-* _sharedLogic_ is the multiplatform module that contains the logic common for both Android and iOS applications.
-* _sharedUI_ is the module with Compose Multiplatform UI code: in this project, it is used only by the Android app,
-  but it is a multiplatform module that can be used by other targets whenever you are ready for that.
+* `sharedLogic` is the multiplatform module that contains the logic common for both Android and iOS applications.
+* `sharedUI` is the module with Compose Multiplatform UI code: in this project, it is used only by the Android app,
+  but it is a multiplatform module and can be used by other targets when needed.
 
 Every module except for `iosApp` uses Gradle as the build system.
 
 ![Basic Multiplatform project structure](basic-project-structure.svg){width=700}
-<!-- TODO need to redo the diagram: ios depends on sharedLogic while android on both sharedLogic and sharedUI -->
 
 _Source set_ is a Gradle concept for a set of files logically grouped together where each set has its own dependencies.
 In Kotlin Multiplatform, different source sets in a shared module can target different platforms.
 
 The `sharedLogic` module contains the `androidMain`, `commonMain`, and `iosMain` source sets.
-The `commonMain` source set contains shared Kotlin code, and platform source sets use Kotlin code specific to each target.
+The `commonMain` source set contains shared Kotlin code, while the platform-specific source sets contain code limited to each platform.
 Kotlin/JVM is used for `androidMain` and Kotlin/Native for `iosMain`:
 
 ![Source sets and modules structure](basic-project-structure-2.png){width=350}
@@ -146,14 +145,14 @@ and generates a single declaration with actual implementations.
     ```
 
     * The `name` property of the `AndroidPlatform` class uses the Android-specific code, namely the `android.os.Build`
-      dependency. This code is interpreted as Kotlin/JVM.
+      class. This code is interpreted as Kotlin/JVM.
       If you try to access a JVM-specific class, such as `java.util.Random` here, this code will compile.
     * The `name` property of the `IOSPlatform` class uses iOS-specific code, namely the `platform.UIKit.UIDevice`
-      dependency. This code is interpreted as Kotlin/Native, meaning that you can refer to iOS declarations in Kotlin.
+      class. This code is interpreted as Kotlin/Native, meaning that you can refer to iOS declarations in Kotlin.
       The code becomes a part of the iOS framework, which is imported in the Swift code of the `iosApp` module.
 
 3. Each source set includes a `getPlatform()` function.
-   Its expected declaration doesn't have a body, and actual implementations are provided in the platform code:
+   Its `expect` declaration doesn't have a body, and `actual` implementations are provided in the platform code:
 
     ```kotlin
     // Platform.kt in the commonMain source set
@@ -173,10 +172,10 @@ and generates a single declaration with actual implementations.
 Here, the common source set defines an expected `getPlatform()` function and has actual implementations,
 `AndroidPlatform()` for the Android app and `IOSPlatform()` for the iOS app, in the platform source sets.
 
-When generating the code for a specific platform, the Kotlin compiler merges expected and actual declarations
+When generating the code for a specific platform, the Kotlin compiler merges `expect` and `actual` declarations
 into a single `getPlatform()` function with the correct implementation.
 
-That's why expected and actual declarations should be defined in the same package – they are merged into one declaration
+That's why `expect` and `actual` declarations need to be defined in the same package – they are merged into one declaration
 in the resulting platform code. Any invocation of the expected `getPlatform()` function in the generated platform code
 then refers to the correct actual implementation.
 

--- a/topics/multiplatform-onboard/multiplatform-dependencies.md
+++ b/topics/multiplatform-onboard/multiplatform-dependencies.md
@@ -28,13 +28,14 @@ There are two types of dependencies that you can use in Kotlin Multiplatform pro
   Many modern Android libraries already have multiplatform support, like [Koin](https://insert-koin.io/),
   [Coil](https://coil-kt.github.io/coil/), and [SQLDelight](https://sqldelight.github.io/sqldelight/latest/).
   Find more multiplatform libraries on [klibs.io](https://klibs.io/),
-  a search service offered by JetBrains for discovering Kotlin Multiplatform libraries.
+  a search service by JetBrains for discovering Kotlin Multiplatform libraries.
 
-* _Native dependencies_. These are regular libraries from specific ecosystems.
-  In native projects you usually work with them, for example, using Gradle for Android and Swift Package Manager for iOS. 
+* _Native dependencies_. These are platform-specific libraries from corresponding ecosystems.
+  In native projects, you typically manage these libraries through platform-specific tools
+  such as Gradle for Android and Swift Package Manager for iOS.
   
   When you work with a multiplatform project module, typically, you still need native dependencies to use platform APIs
-  such as security storage, specific system calls, and so on.
+  such as secure storage, system calls, and so on.
   In the build script, you specify native dependencies in the configuration of native source sets, for example, `androidMain` and `iosMain`.
 
 For both types of dependencies, you can use local and external repositories.
@@ -42,7 +43,8 @@ For both types of dependencies, you can use local and external repositories.
 ## Add a multiplatform dependency
 
 > If you have experience developing Android apps, adding a multiplatform dependency is similar to adding a
-> Gradle dependency in a regular Android project. The only difference is that you need to add it to a specific source set.
+> Gradle dependency to a regular Android project.
+> The only difference is that you need to add the dependency to a specific source set rather than to the module as a whole.
 >
 {style="tip"}
 
@@ -51,7 +53,7 @@ In addition to the OS version, add a function to display the number of days left
 The `kotlinx-datetime` library, which has full multiplatform support, is the most convenient way to work with dates in your shared code.
 
 1. Open the `gradle/libs.versions.toml` file and add the `kotlinx-datetime` dependency to the version catalog:
-    ```text
+    ```toml
     [versions]
     kotlinx-datetime = "0.8.0"
     

--- a/topics/multiplatform-onboard/multiplatform-upgrade-app.md
+++ b/topics/multiplatform-onboard/multiplatform-upgrade-app.md
@@ -43,7 +43,7 @@ You'll need to add the following multiplatform libraries in your project:
 Add the following entries to `gradle/libs.versions.toml`, then sync Gradle files to make the references available
 in build configuration code:
 
-```text
+```toml
 [versions]
 coroutinesVersion = "%coroutinesVersion%"
 ktorVersion = "%ktorVersion%"
@@ -533,7 +533,7 @@ including bridging various Kotlin types to Swift equivalents. It also doesn’t 
 
 1. Add the KMP-NativeCoroutines version and plugin reference to the Gradle version catalog:
 
-    ```text
+    ```toml
     [versions]
     kmpNativeCoroutines = "%kmpncVersion%"
     
@@ -673,7 +673,7 @@ every time the flow emits a value.
 
 To set up the library, add the SKIE version and plugin reference to your Gradle version catalog:
 
-```text
+```toml
 [versions]
 skie = "%skieVersion%"
 

--- a/topics/tools/compose-hot-reload.md
+++ b/topics/tools/compose-hot-reload.md
@@ -59,7 +59,7 @@ The steps refer to the project from the [Create an app with shared logic and UI]
  
 2. Update the version catalog with the latest version of Compose Hot Reload (see [Releases](https://github.com/JetBrains/compose-hot-reload/releases)).
    In `gradle/libs.versions.toml`, add the following code:
-   ```text
+   ```toml
    composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload"}
    ```
 


### PR DESCRIPTION
Addressed comments lost in the interim branch between [this PR](https://github.com/JetBrains/kotlin-multiplatform-dev-docs/pull/630) and `master`.

Also put TOML as highlighting language for all version catalog code blocks.
