### PR TITLE
fix: correct missing ref and references

### DIFF
--- a/topics/multiplatform-onboard/multiplatform-upgrade-app.md
+++ b/topics/multiplatform-onboard/multiplatform-upgrade-app.md
@@ -55,8 +55,8 @@ kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core",
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorVersion" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorVersion" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorVersion" }
-ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
-ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktorVersion" }
+ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktorVersion" }
 
 [plugins]
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -78,7 +78,7 @@ kotlin {
             // ...
             // The Kotlin Multiplatform Gradle plugin adds
             // platform-specific coroutines artifacts automatically
-            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.coroutines)
             // Main Ktor dependency
             implementation(libs.ktor.client.core)
             // Dependencies that allow Ktor to use serialization


### PR DESCRIPTION
When I was going through the flow I found a couple mismatched refs and typos that prevented me from building the app. Not sure if this is the right fix for the doc but doing it this way helped me progress through the tutorial here: https://kotlinlang.org/docs/multiplatform/multiplatform-create-first-app.html