### PR TITLE
fix: split  toc-element into visible link and hidden redirect

### DIFF
--- a/mpd.tree
+++ b/mpd.tree
@@ -6,7 +6,8 @@
 	<toc-element toc-title="Kotlin Multiplatform overview">
 		<toc-element toc-title="What is Kotlin Multiplatform" topic="kmp-overview.md"/>
 		<toc-element toc-title="Supported platforms" topic="supported-platforms.md"/>
-        <toc-element toc-title="Case studies" accepts-web-file-names="case-studies.html" target-for-accept-web-file-names="https://kotlinlang.org/case-studies/?type=multiplatform"/>
+		<toc-element toc-title="Case studies" href="https://kotlinlang.org/case-studies/?type=multiplatform"/>
+        <toc-element toc-title="Case studies" hidden="true" accepts-web-file-names="case-studies.html" target-for-accept-web-file-names="https://kotlinlang.org/case-studies/?type=multiplatform"/>
 		<toc-element toc-title="Samples" topic="multiplatform-samples.md"/>
         <toc-element topic="kmp-learning-resources.md"/>
         <toc-element topic="faq.md"/>


### PR DESCRIPTION
After updating the version of writerside builder the check TOC020 (Target for external redirect must be a hidden TOC element) became strict (example of [failure](https://buildserver.labs.intellij.net/buildConfiguration/Kotlin_KotlinSites_KotlinlangTeamcityDsl_KotlinMultiplatform/996164469?buildTab=log&logView=flowAware&linesState=1293.2408&focusLine=2429) ), so we need this fix in order to deploy docs with new builder
