### PR TITLE
Improve documentation around CMP Previews

### DIFF
--- a/topics/compose/compose-previews.md
+++ b/topics/compose/compose-previews.md
@@ -22,7 +22,8 @@ On this page, you can find:
 
 ## Preview setup
 
-If you're starting from scratch, you can create a **new project** using the IDE wizard, which comes pre-configured
+If you're starting from scratch, you can create a **new project** using the IDE wizard, which comes pre-configured to display previews if 
+it has an Android target.
 
 To get started, simply install the [Kotlin Multiplatform IDE plugin](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform),
 available for both IntelliJ IDEA and Android Studio.
@@ -104,12 +105,8 @@ combinations that you can use to enable Compose previews:
 * Compose Multiplatform 1.9, with the old `@Preview` annotation and Android configured with `androidTarget {}`.
 * Compose Multiplatform 1.10, with the old `@Preview` annotation and Android configured with `androidTarget {}`.
 * Compose Multiplatform 1.10, with the new `@Preview` annotation and Android configured with `androidTarget {}`.
-* Compose Multiplatform 1.10, with the new `@Preview` annotation and Android configured with `androidLibrary {}` with AGP 9.0.
-  See our [AGP 9.0 migration guide](multiplatform-project-agp-9-migration.md) for details on upgrading your KMP apps.
-
-> Support for AGP 9.0 is coming soon to IntelliJ IDEA, expected to arrive in Q1 2026.
->
-{style="note"}
+* Compose Multiplatform 1.10, with the new `@Preview` annotation and Android configured with `androidLibrary {}` with AGP 9.0+.
+  See our [AGP 9.0 migration guide](multiplatform-project-agp-9-migration.md) for details on setting up and upgrading your KMP apps. 
 
 ### Available annotations
 
@@ -119,30 +116,48 @@ There are two `@Preview` annotations available in Compose Multiplatform:
   * This is the original Android Jetpack annotation, made multiplatform with Compose Multiplatform 1.10.
     It supports all parameters from the Android declaration in common code.
   * The necessary runtime dependency is `org.jetbrains.compose.ui:ui-tooling-preview`.
-  * This is the recommended annotation to use going forward. 
+  * This is the **recommended annotation** to use going forward. 
 * `org.jetbrains.compose.ui.tooling.preview.Preview`
   * This was the first multiplatform implementation of the annotation, emulating the Android-only experience.
     It supports a limited number of parameters, but provides basic preview functionality.
   * The necessary runtime dependency is `org.jetbrains.compose.components:components-ui-tooling-preview`.
-  * This annotation is now deprecated in Compose Multiplatform 1.10.
+  * This annotation is now **deprecated** in Compose Multiplatform 1.10.
 
 To use one of these annotations in your shared code, add the appropriate runtime dependency for your `commonMain`
 source set, [as shown above](#preview-setup).
 
 ### Android target configurations
 
-If your project uses Android Gradle plugin 8.x, the Kotlin Multiplatform part of the project should use either
+#### Android Gradle Plugin 8.x
+The Kotlin Multiplatform part of the project should use either
 the Android application (`com.android.application`) or the Android library (`com.android.library`) plugin,
 and the Android configuration is contained in the `androidTarget {}` block of your `build.gradle.kts` file.
 
-For Android Gradle plugin 9.0, there is a new [KMP Android library plugin](https://developer.android.com/kotlin/multiplatform/plugin)
+#### Android Gradle Plugin 9.0+
+There is a new [KMP Android library plugin](https://developer.android.com/kotlin/multiplatform/plugin)
 (`com.android.kotlin.multiplatform.library`)
 which introduces the `androidLibrary {}` block for Android configuration.
+
 While it's also possible to use this plugin with AGP 8.x, that combination has known issues and is not recommended. 
 
-> AGP 9.0 is supported in the latest stable Android Studio,
-> but not supported in IntelliJ IDEA yet and is expected in Q1 2026.
->
-{style="note"}
+This is an example of a minimal `androidLibrary` block to be able to display `@Preview`s, even when not building an Android application:
+```
+kotlin {
+    androidLibrary {
+        namespace = "your.module.namespace"
+        compileSdk = 36
+
+        androidResources {
+            enable = true
+        }
+
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_21
+        }
+    }
+    ...
+}
+```
+
 
 For details on upgrading to AGP 9.0, see [our migration page](multiplatform-project-agp-9-migration.md).


### PR DESCRIPTION
* Added clarity for CMP users creating a project without an Android target: previews won't work automatically for them. 
* Removed the notes concerning the fact that AGP 9.0 wasn't supported in Intellij Idea
* Added a "minimal Android gradle configuration" for Previews to work without an Android application target. 