### PR TITLE
Retroactively Update What's New pages re. skiko.js requirements

### DIFF
--- a/topics/whats-new/whats-new-compose-170.md
+++ b/topics/whats-new/whats-new-compose-170.md
@@ -381,6 +381,6 @@ The `skiko.js` file is now redundant for Kotlin/Wasm applications built with Com
 You can remove it from the `index.html` file and improve the load times of your app.
 `skiko.js` will be removed from the Kotlin/Wasm distribution completely in future releases.
 
-> The `skiko.js` file is still necessary for Kotlin/JS applications.
-> 
+> The `skiko.js` file is still necessary for Kotlin/JS applications, up to Compose Multiplatform 1.9.0.
+> See [What's new in Compose Multiplatform 1.9.3](whats-new-compose-190.md#skikojs-is-no-longer-needed) for when that changed.
 {style="note"}

--- a/topics/whats-new/whats-new-compose-190.md
+++ b/topics/whats-new/whats-new-compose-190.md
@@ -9,6 +9,7 @@ Here are the highlights for this feature release:
 * [Frame rate configuration on iOS](#frame-rate-configuration)
 * [Compose Multiplatform for web in Beta](#compose-multiplatform-for-web-in-beta)
 * [Accessibility support on web targets](#accessibility-support)
+* [skiko.js no longer needed for Kotlin/JS](#skikojs-is-no-longer-needed)
 * [New API for embedding HTML content](#new-api-for-embedding-html-content)
 
 See the full list of changes for this release on [GitHub](https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.9.0).
@@ -243,6 +244,15 @@ ComposeViewport(
     Text("Hello, Compose Multiplatform for web")
 }
 ```
+
+### skiko.js is no longer needed
+
+Since Compose Multiplatform 1.7.0, `skiko.js` has been redundant for Kotlin/Wasm applications.
+As of this release, the same is true for Kotlin/JS: Skiko's web runtime now ships as an ES
+module and is bundled directly into your app's compiled JavaScript, so a separate `skiko.js`
+script is no longer required for either web target.
+
+You can remove the `<script src="skiko.js">` tag from your `index.html` file.
 
 ### New API for embedding HTML content
 


### PR DESCRIPTION
Since this is something that cost me a while during our own updates:

As of Compose Multiplatform 1.9.0, skiko.js is no longer required for Kotlin/JS either. It was already redundant for Kotlin/Wasm since 1.7.0. Added a short section to the 1.9.3 what's new page for this, and pointed the old note on the 1.7.0 page at it.

This info was previously somewhat hard to find, only in the changelog, which doesn't readily appear in Google searches.