### PR TITLE
fix(): point to kotlin release instead of compose in header

### DIFF
--- a/cfg/buildprofiles.xml
+++ b/cfg/buildprofiles.xml
@@ -9,7 +9,7 @@
         <analytics-head-script-file>thirdparty/dpk-gtm-analytics.html</analytics-head-script-file>
         <website-title>%instance% Documentation</website-title>
         <automaticLinkSummaries>false</automaticLinkSummaries>
-        <product-web-url>%kmpLatestUrl%</product-web-url>
+        <product-web-url>%kotlinLatestUrl%</product-web-url>
         <web-root>https://kotlinlang.org/docs/multiplatform/</web-root>
         <og-image>https://kotlinlang.org/assets/images/open-graph/docs.png</og-image>
         <og-twitter>@kotlin</og-twitter>

--- a/v.list
+++ b/v.list
@@ -6,7 +6,7 @@
     <!-- Kotlin -->
     <var name="kotlinVersion" value="2.4.10"/>
     <var name="kotlinEapVersion" value="2.4.20-Beta2"/>
-    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0"/>
+    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.4.10"/>
     <var name="kmpLatestUrl" value="https://github.com/JetBrains/compose-multiplatform/releases"/>
     <var name="languageVersion" value="2.4"/>
     <var name="apiVersion" value="2.4"/>


### PR DESCRIPTION
Fixes this 
<img width="854" height="562" alt="Screenshot 2026-09-02 at 12-16-04" src="https://github.com/user-attachments/assets/cff20525-e296-4f5f-94db-4751654a0a40" />
<img width="794" height="567" alt="Screenshot 2026-09-02 at 12-17-13" src="https://github.com/user-attachments/assets/db9c90a6-fe5c-4192-b21c-1262539195b6" />
