### PR TITLE
Fix web locale switching example for cached Locale.current

### DIFF
--- a/topics/compose/compose-resource-environment.md
+++ b/topics/compose/compose-resource-environment.md
@@ -124,10 +124,6 @@ provide the corresponding declarations for each platform using the platform-spec
  a custom locale logic:
 
     ```kotlin
-    external object window {
-        var __customLocale: String?
-    }
-    
     actual object LocalAppLocale {
         private val LocalAppLocale = staticCompositionLocalOf { Locale.current }
         actual val current: String
@@ -135,9 +131,21 @@ provide the corresponding declarations for each platform using the platform-spec
     
         @Composable
         actual infix fun provides(value: String?): ProvidedValue<*> {
-            window.__customLocale = value?.replace('_', '-')
+            updateCustomLocale(value?.replace('_', '-'))
             return LocalAppLocale.provides(Locale.current)
         }
+    }
+    
+    @OptIn(ExperimentalWasmJsInterop::class)
+    private fun updateCustomLocale(value: String?) {
+        js(
+            """
+            if (window.__customLocale !== value) {
+                window.__customLocale = value;
+                window.dispatchEvent(new Event("languagechange"));
+            }
+            """
+        )
     }
     ```
 


### PR DESCRIPTION
After https://github.com/JetBrains/compose-multiplatform-core/pull/3397 (in CMP 1.13) the locale switching in Web should be updated